### PR TITLE
Enable -Os back to bluedroid

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -18,6 +18,8 @@ ifneq ($(BOARD_BLUETOOTH_BDROID_HCILP_INCLUDED),)
   bdroid_CFLAGS += -DHCILP_INCLUDED=$(BOARD_BLUETOOTH_BDROID_HCILP_INCLUDED)
 endif
 
+bdroid_CFLAGS += -Os
+
 include $(call all-subdir-makefiles)
 
 # Cleanup our locals


### PR DESCRIPTION
Using plain -O3 causes bluetooth to not work properly.
Fix this by adding -Os to the CFLAGS.

Signed-off-by: Park Ju Hyung qkrwngud825@gmail.com
